### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ This should generate the following output:
   0.9811802506446838],
  ['paypal.com', 0.2289438247680664]]`
  
-## Dependencies (install these with pip)
+## Dependencies
+
+###### Install with Pip (pip install)
 
 * keras
 * h5py
@@ -44,9 +46,11 @@ This should generate the following output:
 * scipy
 * numpy
 * sklearn
-* sqlite3
 * zerorpc
 * peewee
+
+###### Install with Apt (apt-get install)
+* sqlite3
 
 ## Training new models
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This project uses [keras](http://keras.io "keras") to implement a character-leve
 
 eXpose uses [zerorpc](http://www.zerorpc.io/ "ZeroRPC") to host the neural network models as RPC services.  From the top level project directory, you can run the eXpose model in three different modes: URL detection mode, path detection mode, and registry key path detection mode, as follows:
 
-`python model_server.py ../data/urls`
+`python model_server.py ../data/models/urls`
 
-`python model_server.py ../data/paths`
+`python model_server.py ../data/models/paths`
 
-`python model_server.py ../data/registry`
+`python model_server.py ../data/models/registry`
 
 These commands start a model RPC server and load in trained neural network weights from the data directory such that the neural network will know how to perform detection on the object of interest.  An example client for the model servers is provided in `src/example_model_client.py` for your convenience.  This script tests the URL detection functionality of eXpose.  You can run this test as follows:
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This should generate the following output:
 * sklearn
 * zerorpc
 * peewee
+* tensorflow
 
 ###### Install with Apt (apt-get install)
 * sqlite3


### PR DESCRIPTION
### Minor README Update

**SQLite3** dependency is not normally installed using pip but rather using apt-get (e.g.  `apt-get install sqlite3 libsqlite3-dev`)